### PR TITLE
Change the config production file

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,6 @@ Rails.application.configure do
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   config.require_master_key = true
-  heroku config:set RAILS_MASTER_KEY=ENV['RAILS_MASTER_KEY']
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
Remove the `heroku config:set RAILS_MASTER_KEY=ENV['RAILS_MASTER_KEY']` from production.rb file. It has to be entered in the concole.