### PR TITLE
Tr type

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -51,17 +51,22 @@ class PortfoliosController < ApplicationController
     @portfolio = Portfolio.new(portfolio_params)
 
     respond_to do |format|
-      if @portfolio.save
-        format.html do
-          redirect_to "/users/#{current_user.id}/portfolios/#{@portfolio.id}",
-                      notice: 'Portfolio was successfully created.'
+      unless @portfolios.any? { |p| p.name == @portfolio.name }
+        if @portfolio.save
+          format.html do
+            redirect_to "/users/#{current_user.id}/portfolios/#{@portfolio.id}",
+                        notice: 'Portfolio was successfully created.'
+          end
+          create_cash_position
+          format.json { render :show, status: :created, location: @portfolio }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @portfolio.errors, status: :unprocessable_entity }
         end
-        create_cash_position
-        format.json { render :show, status: :created, location: @portfolio }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @portfolio.errors, status: :unprocessable_entity }
-      end
+        format.html do
+          redirect_to "/users/#{current_user.id}/portfolios/#{@portfolio.id}", notice: 'Portfolio with this name already exists.'
+        end
     end
   end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -61,7 +61,7 @@ class TransactionsController < ApplicationController
             transaction_save(@transaction, format)
           else
             format.html do
-              redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Not enough long shares to complete the transaction.'
+              redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Not enough shares to complete the transaction.'
             end
           end
         else

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -37,6 +37,10 @@ class TransactionsController < ApplicationController
 
     respond_to do |format|
       case @transaction.tr_type
+      when ''
+        format.html do
+          redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Please, select one of the transaction types.'
+        end
       when 'Buy'
         if enough_cash?(@transaction)
           if short_position_exist?(@transaction)

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -15,6 +15,16 @@ module TransactionsHelper
     @stock = @stocks.find_by(ticker: @transaction.symbol)
   end
 
+  def transaction_type
+    [
+      ['Transaction type', ''],
+      ['Buy', 'Buy'],
+      ['Sell', 'Sell'],
+      ['Sell short', 'Sell short'],
+      ['Buy to cover', 'Buy to cover']
+    ]
+  end
+
   def transaction_amount(transaction)
     transaction.quantity * transaction.price
   end
@@ -29,7 +39,7 @@ module TransactionsHelper
     @cash_position = Position.where(portfolio_id: params[:portfolio_id], symbol: 'Cash').first
     if transaction.tr_type == 'Buy' || transaction.tr_type == 'Buy to cover'
       @transaction_buy_cost = transaction_amount(transaction) + add_cost(transaction)
-    else
+    elsif transaction.tr_type == 'Sell' || transaction.tr_type == 'Sell short'
       @transaction_buy_cost = transaction_amount(transaction) - add_cost(transaction)
     end
     @cash_position.quantity >= @transaction_buy_cost
@@ -150,6 +160,7 @@ module TransactionsHelper
     transaction.commission.nil? ? transaction.commission = 0 : transaction.commission
     transaction.fee.nil? ? transaction.fee = 0 : transaction.fee
     case transaction.tr_type
+    when ''
     when 'Buy'
       if enough_cash?(transaction)
         if symbol_exist?(transaction)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,4 +1,4 @@
 class Transaction < ApplicationRecord
   belongs_to :portfolio
-  validates :tr_type, presence: true
+  validates :tr_type, :trade_date, :symbol, :quantity, :price,  presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,16 +22,12 @@
   <body>
     <main class="container mx-auto mt-12 px-5 flex-col">
       <div class="container flex justify-center align-center">
-        <%
-=begin%>
- <% if notice %>
+        <% if notice %>
           <span class="bg-green-100 text-green-500 mb-2 p-2 rounded-md"><%= notice %></span>
         <% end %>
         <% if alert %>
           <span class="bg-red-100 text-red-500 mb-2 p-2 rounded-md"><%= alert %></span>
         <% end %> 
-<%
-=end%>
       </div>
       <header class="container bg-dollar">
         <nav class="mb-6">

--- a/app/views/portfolios/_form.html.erb
+++ b/app/views/portfolios/_form.html.erb
@@ -1,5 +1,7 @@
 <%= form_with(model: @portfolio, url: "/users/#{current_user.id}/portfolios", class: "contents w-1/4") do |form| %>
-  <% if portfolio.errors.any? %>
+  <%
+=begin%>
+ <% if portfolio.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(portfolio.errors.count, "error") %> prohibited this portfolio from being saved:</h2>
       <ul>
@@ -8,7 +10,9 @@
         <% end %>
       </ul>
     </div>
-  <% end %>
+  <% end %> 
+<%
+=end%>
 
   <div class="my-5">
     <%= form.label :name %>

--- a/app/views/portfolios/index.html.erb
+++ b/app/views/portfolios/index.html.erb
@@ -8,7 +8,9 @@
   </div>
 
   <div class="flex justify-between w-1/4 mb-8">
-    <%= link_to 'Update prices', user_portfolios_path, class: "rounded-lg py-1 px-3 bg-dollar text-white block font-medium hover:bg-dollar-darker" %>
+    <% unless @portfolios.length == 0 || @positions.length == 1 %>
+      <%= link_to 'Update prices', user_portfolios_path, class: "rounded-lg py-1 px-3 bg-dollar text-white block font-medium hover:bg-dollar-darker" %>
+    <% end %>
     <%= link_to 'New portfolio', new_user_portfolio_path, class: "rounded-lg py-1 px-3 bg-dollar-split_blue text-white block font-medium hover:bg-dollar-triad_blue" %>
   </div>
 

--- a/app/views/portfolios/show.html.erb
+++ b/app/views/portfolios/show.html.erb
@@ -1,11 +1,6 @@
 <div class="mx-auto md:w-4/4 w-full flex">
   <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-
     <%= render @portfolio %>
-
     <%= link_to 'Edit this portfolio', "/users/#{current_user.id}/portfolios/#{@portfolio.id}/edit", class: "mt-2 rounded-lg py-1 px-3 bg-dollar-split_blue text-white inline-block font-medium hover:bg-dollar-triad_blue" %>
     <div class="inline-block ml-2">
       <%= button_to 'Destroy this portfolio', "/users/#{current_user.id}/portfolios/#{@portfolio.id}", method: :delete, class: "mt-2 rounded-lg py-1 px-3 bg-dollar-triad_red font-medium text-white hover:bg-dollar-square_red" %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -11,12 +11,7 @@
   <% end %>
 
   <div class="my-5">
-    <%= form.select :tr_type, [["Transaction type", ''],
-      ['Buy', 'Buy'],
-      ['Sell', 'Sell'],
-      ['Sell short', 'Sell short'],
-      ['Buy to cover', 'Buy to cover']],
-      class:"block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full text-red-800", required: true %>
+    <%= form.select :tr_type, transaction_type, value: '', class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full text-slate-300", required: true %>
   </div>
 
   <div class="my-5">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -1,7 +1,4 @@
 <div class="w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
 
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl mb-8">Transactions</h1>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -1,9 +1,5 @@
 <div class="mx-auto md:w-3/4 w-full flex">
   <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-
     <table class="table-auto mb-6 border-collapse border border-slate-400">
       <thead>
         <tr>


### PR DESCRIPTION
Make transactioin_type mandatory field ad can't save a transaction nor stock without a valid tr_type.
Remove some of the duplicated notices and alerts.
Prevent having a portfolio with the same name.