### PR TITLE
Fix a bug which allowed to save a closing transaction before the open…

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -61,7 +61,13 @@ class TransactionsController < ApplicationController
           when 'Sell'
             unless short_position_exist?(@transaction)
               if enough_shares?(@transaction)
-                transaction_save(@transaction, format)
+                if closing_date_earlier_than_opening_date?(@transaction)
+                  format.html do
+                    redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Trying to record a sell transaction before the buy transaction. Check your transaction date!'
+                  end
+                else
+                  transaction_save(@transaction, format)
+                end
               else
                 format.html do
                   redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Not enough shares to complete the transaction.'
@@ -85,7 +91,13 @@ class TransactionsController < ApplicationController
               if short_position_exist?(@transaction)
                 if enough_cash?(@transaction)
                   if enough_shares?(@transaction)
-                    transaction_save(@transaction, format)
+                    if closing_date_earlier_than_opening_date?(@transaction)
+                      format.html do
+                        redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Trying to record a buy to cover transaction before the sell short transaction. Check your transaction date!'
+                      end
+                    else
+                      transaction_save(@transaction, format)
+                    end
                   else
                     format.html do
                       redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Not enough short shares to complete the transaction.'
@@ -109,7 +121,7 @@ class TransactionsController < ApplicationController
           end
         else
           format.html do
-            redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Transaction date is before the open date of the portfolio.'
+            redirect_to "/users/#{current_user.id}/portfolios/#{params[:id]}/transactions/#{params[:id]}", alert: 'Transaction date is before the portfolio open date.'
           end
         end
       else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>PortfolioTracker</title>
+    <title>Portfolio Tracker</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -14,7 +14,6 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
       gtag('config', 'G-03RH6D64MR');
     </script>
   </head>


### PR DESCRIPTION
There was a bug that would allow the user to record a closing transaction (sell or buy to cover) before (with an earlier trading date) than the opening transaction for the same security (buy or sell short). Wrote a new method closing_date_earlier_than_opening_date? to verify this and update the controller and helper functions create_update_stock and create_update_position methods.