### PR TITLE
Hide/Show new transaction fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -269,6 +271,8 @@ GEM
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strscan (3.0.3)
+    tailwindcss-rails (2.0.10-arm64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.10-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -296,6 +300,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -17,18 +17,6 @@ module TransactionsHelper
     @stock = @stocks.find_by(ticker: @transaction.symbol)
   end
 
-  def transaction_type
-    [
-      ['Transaction type', ''],
-      ['Buy', 'Buy'],
-      ['Sell', 'Sell'],
-      ['Sell short', 'Sell short'],
-      ['Buy to cover', 'Buy to cover'],
-      ['Cash in', 'Cash in'],
-      ['Cash out', 'Cash out']
-    ]
-  end
-
   def transaction_amount(transaction)
     transaction.quantity * transaction.price
   end

--- a/app/javascript/controllers/forms_controller.js
+++ b/app/javascript/controllers/forms_controller.js
@@ -1,20 +1,36 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  connect() {
-    console.log("Hello, Stimulus!", this.element)
+  static targets = [
+    "toggleableSymbol",
+    "toggleableQuantity",
+    "toggleableCommission",
+    "toggleableFee"
+  ]
+
+  initialize() {
+    console.log("Initializing Stimulus!")
   }
 
-  example() {
-    const tr_type = document.getElementById('transaction_tr_type');
-    tr_type.addEventListener('change', tr_type_change);
+  connect() {
+    console.log("connected to forms controller")
+  }
 
-    function tr_type_change() {
-      console.log(tr_type.value);
-      if (tr_type.value === 'Cash in' || tr_type.value === 'Cash out') {
-        let trade_symbol = document.getElementById('trade_symbol');
-        trade_symbol.classList.add('hidden');
-      }
+  handleChange() {
+    const tr_type = document.getElementById('transaction_product_type')
+
+    if (this.toggleableSymbolTarget.classList.contains('hidden')) {
+      this.toggleableSymbolTarget.classList.toggle('hidden')
+      this.toggleableQuantityTarget.classList.toggle('hidden')
+      this.toggleableCommissionTarget.classList.toggle('hidden')
+      this.toggleableFeeTarget.classList.toggle('hidden')
+    }
+
+    if (tr_type.value === 'Cash in' || tr_type.value === 'Cash out') {
+      this.toggleableSymbolTarget.classList.toggle('hidden')
+      this.toggleableQuantityTarget.classList.toggle('hidden')
+      this.toggleableCommissionTarget.classList.toggle('hidden')
+      this.toggleableFeeTarget.classList.toggle('hidden')
     }
   }
 }

--- a/app/javascript/controllers/forms_controller.js
+++ b/app/javascript/controllers/forms_controller.js
@@ -17,20 +17,21 @@ export default class extends Controller {
   }
 
   handleChange() {
-    const tr_type = document.getElementById('transaction_product_type')
-
-    if (this.toggleableSymbolTarget.classList.contains('hidden')) {
-      this.toggleableSymbolTarget.classList.toggle('hidden')
-      this.toggleableQuantityTarget.classList.toggle('hidden')
-      this.toggleableCommissionTarget.classList.toggle('hidden')
-      this.toggleableFeeTarget.classList.toggle('hidden')
+    if (this.toggleableSymbolTarget.classList.contains('hidden') || transactionTypeCondition()) {
+      hideOrShowFields
     }
+  }
 
-    if (tr_type.value === 'Cash in' || tr_type.value === 'Cash out') {
-      this.toggleableSymbolTarget.classList.toggle('hidden')
-      this.toggleableQuantityTarget.classList.toggle('hidden')
-      this.toggleableCommissionTarget.classList.toggle('hidden')
-      this.toggleableFeeTarget.classList.toggle('hidden')
-    }
+  transactionTypeCondition() {
+    const transaction_type = document.getElementById('transaction_product_type')
+
+    transaction_type.value === 'Cash in' || transaction_type.value === 'Cash out'
+  }
+
+  hideOrShowFields() {
+    this.toggleableSymbolTarget.classList.toggle('hidden')
+    this.toggleableQuantityTarget.classList.toggle('hidden')
+    this.toggleableCommissionTarget.classList.toggle('hidden')
+    this.toggleableFeeTarget.classList.toggle('hidden')
   }
 }

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,51 +1,52 @@
-<%= form_with(model: transaction, url: "/users/#{current_user.id}/portfolios/#{params[:portfolio_id]}/transactions/", class: "contents") do |form| %>
-  <% if transaction.errors.any? %>
-    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(transaction.errors.count, "error") %> prohibited this transaction from being saved:</h2>
-      <ul>
-        <% transaction.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
+<div data-controller="forms">
+  <%= form_with(model: transaction, url: "/users/#{current_user.id}/portfolios/#{params[:portfolio_id]}/transactions/", class: "contents") do |form| %>
+    <% if transaction.errors.any? %>
+      <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+        <h2><%= pluralize(transaction.errors.count, "error") %> prohibited this transaction from being saved:</h2>
+        <ul>
+          <% transaction.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="my-5">
+      <%= form.collection_select :product_type, ['', 'Buy', 'Sell', 'Sell short', 'Buy to cover', 'Cash in', 'Cash out'],
+                                :to_s,
+                                :titlecase,
+                                {},
+                                data: { action: "change->forms#handleChange" } %>
+    </div>
+
+    <div class="my-5">
+      <%= form.date_field :trade_date, value: Date.today, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Trade date" %>
+    </div>
+
+    <div class="my-5" data-forms-target="toggleableSymbol">
+      <%= form.text_field :symbol, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Symbol" %>
+    </div>
+
+    <div class="my-5"  data-forms-target="toggleableQuantity">
+      <%= form.number_field :quantity, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Quantity" %>
+    </div>
+
+    <div class="my-5">
+      <%= form.number_field :price, step: 0.01, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Price" %>
+    </div>
+
+    <div class="my-5"  data-forms-target="toggleableCommission">
+      <%= form.number_field :commission, step: 0.01, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"Commission" %>
+    </div>
+
+    <div class="my-5"  data-forms-target="toggleableFee">
+      <%= form.number_field :fee, step: 0.01, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"Fee" %>
+    </div>
+
+    <%= form.hidden_field :portfolio_id, value: @portfolio.id %>
+
+    <div class="inline">
+      <%= form.submit class: "rounded-lg py-1 px-3 bg-dollar-split_blue text-white inline-block font-medium cursor-pointer hover:bg-dollar-triad_blue" %>
     </div>
   <% end %>
-
-  <div class="my-5">
-      <%= form.select :tr_type, transaction_type, value: '', name: "transaction[tr_type]",
-        data: {
-                id: 'transaction_tr_type',
-                action: "transactions#example",
-              },
-        required: true, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.date_field :trade_date, value: Date.today, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Trade date" %>
-  </div>
-
-  <div class="my-5" id="trade_symbol">
-    <%= form.text_field :symbol, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Symbol" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.number_field :quantity, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Quantity" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.number_field :price, step: 0.01, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", required: true, placeholder:"Price" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.number_field :commission, step: 0.01, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"Commission" %>
-  </div>
-
-  <div class="my-5">
-    <%= form.number_field :fee, step: 0.01, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder:"Fee" %>
-  </div>
-
-  <%= form.hidden_field :portfolio_id, value: @portfolio.id %>
-
-  <div class="inline">
-    <%= form.submit class: "rounded-lg py-1 px-3 bg-dollar-split_blue text-white inline-block font-medium cursor-pointer hover:bg-dollar-triad_blue" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-1/4 w-full" data-controller='forms'>
+<div class="mx-auto md:w-1/4 w-full">
   <h1 class="font-bold text-4xl">New transaction</h1>
 
   <%= render "form", transaction: @transaction %>


### PR DESCRIPTION
When selecting `Check in` or `Check out` option, hide `Symbol`, `Quantity`, `Commission`, `Fee` fields, otherwise show them.