### PR TITLE
Dividend short

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -3,6 +3,7 @@ require_relative '../helpers/transactions_helper'
 class TransactionsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_transaction, only: %i[show edit update destroy]
+
   include TransactionsHelper
 
   # GET /transactions or /transactions.json
@@ -35,6 +36,7 @@ class TransactionsController < ApplicationController
 
     respond_to do |format|
       if ticker_exist?(@transaction)
+        # @transaction.symbol = @transaction.symbol.upcase
         if date_valid?(@transaction)
           case @transaction.tr_type
           when ''

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -146,9 +146,23 @@ class TransactionsController < ApplicationController
               else
                 transaction_save(@transaction, format)
               end
+            elsif short_position_exist?(@transaction)
+              if enough_cash?(@transaction)
+                if closing_date_earlier_than_opening_date?(@transaction)
+                  format.html do
+                    redirect_to current_transaction, alert: 'Trying to record a dividend transaction before the sell short transaction. Check your transaction date!'
+                  end
+                else
+                  transaction_save(@transaction, format)
+                end
+              else
+                format.html do
+                  redirect_to current_transaction, alert: 'Not enough cash to complete the transaction. Raise more cash before recording a dividend transaction for short position.'
+                end
+              end
             else
               format.html do
-                redirect_to current_transaction, alert: 'You do not have a long position in this security.'
+                redirect_to current_transaction, alert: 'You do not have a position in this security.'
               end
             end
           when 'Reinvest Div.'

--- a/app/javascript/controllers/forms_controller.js
+++ b/app/javascript/controllers/forms_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   }
 
   initialize() {
-    this.element.setAttribute('data-action', 'change->forms#handleChange');
+    this.element.setAttribute('data-action', 'change->forms#handleChange input->forms#handleInput');
   }
 
   getFields(transactionType) {
@@ -181,5 +181,12 @@ export default class extends Controller {
         this.showAllFields();
         this.hideUncommonFields();
     }
+  }
+
+  handleInput(event) {
+    const symbol = document.getElementById('transaction_symbol');
+    const newSymbol = document.getElementById('transaction_new_symbol');
+    symbol.value = symbol.value.toUpperCase();
+    newSymbol.value = newSymbol.value.toUpperCase();
   }
 }

--- a/app/views/portfolios/_portfolio.html.erb
+++ b/app/views/portfolios/_portfolio.html.erb
@@ -86,7 +86,8 @@
             <td class="border border-slate-300 px-2 text-red-600"><%= number_to_currency(-1 * stock_in_position.commission_and_fee) %></td>
             <% red_or_green = position.realized_profit_loss >= 0 ? 'text-green-600' : 'text-red-600' %>
             <td class="border border-slate-300 px-2 <%= red_or_green %>"><%= number_to_currency(position.realized_profit_loss) %></td>
-            <td class="border border-slate-300 px-2 text-green-600"><%= number_to_currency(position.income) %></td>
+            <% red_or_green = position.income >= 0 ? 'text-green-600' : 'text-red-600' %>
+            <td class="border border-slate-300 px-2 <%= red_or_green %>"><%= number_to_currency(position.income) %></td>
             <td class="border border-slate-300 px-2"><%= number_to_currency(position.reinvested_income) %></td>
             <td class="border border-slate-300 px-2"><%= number_to_currency(position_value) %></td>
             <td class="border border-slate-300 px-2"><%= position.open_date %></td>

--- a/app/views/stocks/_stock.html.erb
+++ b/app/views/stocks/_stock.html.erb
@@ -22,7 +22,8 @@
 
   <div class="mb-2 mr-4">
     <span class="inline-block font-medium mb-1">Your income is:</span>
-    <span class="font-bold text-green-600"><%= number_to_currency(stock.income.round(2)) %></span>
+    <% red_or_green = stock.income >= 0 ? 'text-green-600' : 'text-red-600' %>
+    <span class="font-bold <%= red_or_green %>"><%= number_to_currency(stock.income.round(2)) %></span>
   </div>
 
   <div class="mb-2 mr-4">

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -24,7 +24,8 @@
       <td class="border border-slate-300 px-4 text-red-600"><%= number_to_currency(-1 * (transaction_amount + added_cost)) %></td>
       <% @income_spent -= transaction_amount + added_cost %>
     <% elsif transaction.tr_type == 'Sell' || transaction.tr_type == 'Sell short' || transaction.tr_type == 'Cash In' || transaction.tr_type == 'Interest Inc.' || transaction.tr_type == 'Dividend' || transaction.tr_type == 'Reinvest Div.' %>
-      <td class="border border-slate-300 px-4 text-green-600"><%= number_to_currency(transaction_amount - added_cost) %></td>
+      <% red_or_green = transaction_amount - added_cost >= 0 ? 'text-green-600' : 'text-red-600' %>
+      <td class="border border-slate-300 px-4 <%= red_or_green %>"><%= number_to_currency(transaction_amount - added_cost) %></td>
       <% @income_spent += transaction_amount - added_cost %>
     <% elsif transaction.tr_type ==  'Stock Split' %>
       <td class="border border-slate-300 px-4"></td>


### PR DESCRIPTION
Implemented a Dividend transaction for short positions.
Before that, Dividend transaction was only possible for existing long positions. With this change, if you have a short position you will be able to record a Dividend transaction and the dividend amount will be deducted from the cash. If you do not have enough cash, you have to raise more cash first, either by closing some positions or by entering Cashh In, Interest Inc., or Dividend for long position transactions. This is because the portfolio is not for margin accounts. The cash balance can not go negative for such an account.
Another improvement is that the input for Symbol and New Symbol fields have been capitalized and submitted in all caps letters regardless of the user's input.