### PR TITLE
Fix a bug with cash transactions not able to record due to handleInput

### DIFF
--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -62,7 +62,8 @@ module TransactionsHelper
     elsif transaction.tr_type == 'Cash In' || transaction.tr_type == 'Interest Inc.'
       existing_stock_opened_date = @portfolio.opened_date
     elsif transaction.tr_type == 'Cash Out' || transaction.tr_type == 'Misc. Exp.'
-      cash_in = Transaction.where(symbol: transaction.symbol, tr_type: 'Cash In').order('trade_date ASC').first
+      cash_in = Transaction.where(symbol: transaction.symbol, tr_type: 'Cash In').order('trade_date ASC').first ||
+                Transaction.where(symbol: transaction.symbol, tr_type: 'Interest Inc.').order('trade_date ASC').first
       cash_in == nil ? existing_stock_opened_date = @portfolio.opened_date : existing_stock_opened_date = cash_in.trade_date
     elsif transaction.tr_type == 'Stock Split' || transaction.tr_type == 'Dividend'
       existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, tr_type: 'Buy').order('trade_date ASC').first.trade_date if long_position_exist?(transaction)

--- a/app/javascript/controllers/forms_controller.js
+++ b/app/javascript/controllers/forms_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   }
 
   initialize() {
-    this.element.setAttribute('data-action', 'change->forms#handleChange input->forms#handleInput');
+    this.element.setAttribute('data-action', 'change->forms#handleChange'); // This  input->forms#handleInput is not working
   }
 
   getFields(transactionType) {
@@ -133,7 +133,7 @@ export default class extends Controller {
   handleChange(event) {
     event.preventDefault();
     const selectedTransactionType = document.getElementById('transaction_tr_type');
-    switch(selectedTransactionType.value) {
+    switch (selectedTransactionType.value) {
       case 'Cash In':
       case 'Cash Out':
       case 'Interest Inc.':
@@ -168,10 +168,10 @@ export default class extends Controller {
     }
   }
 
-  handleInput(event) {
-    const symbol = document.getElementById('transaction_symbol');
-    const newSymbol = document.getElementById('transaction_new_symbol');
-    symbol.value = symbol.value.toUpperCase();
-    newSymbol.value = newSymbol.value.toUpperCase();
-  }
+  // handleInput(event) {
+  //   const symbol = document.getElementById('transaction_symbol');
+  //   const newSymbol = document.getElementById('transaction_new_symbol');
+  //   symbol.value = symbol.value.toUpperCase();
+  //   newSymbol.value = newSymbol.value.toUpperCase();
+  // }
 }


### PR DESCRIPTION
There was a bug introduced in the Dividend-short branch when forms_controller was modified to handle input and made all symbols entered in up-case letters.
I could not fix the problem but disabled the method and the problem disappeared.
Needs investigation.