### PR TITLE
Refact3

### DIFF
--- a/app/helpers/portfolios_helper.rb
+++ b/app/helpers/portfolios_helper.rb
@@ -10,18 +10,22 @@ module PortfoliosHelper
     @total_comm_and_fee = 0
     @total_position_gain = 0
     @total_income = 0
-    @position_profit_loss = 0
     @total_portfolio_value = 0
+    @total_reinvested_income = 0
+    
+    @position_profit_loss = 0
+
     @closed_stock_rpl = 0
     @closed_stock_income = 0
     @closed_stock_comm_and_fee = 0
+
     @portfolio_closed_rpl = 0
     @portfolio_closed_income = 0
     @portfolio_closed_comm_and_fee = 0
-    @closed_stock_gain = 0
-    @total_closed_stock_gain = 0
-    @total_reinvested_income = 0
     @portfolio_closed_reinvested_income = 0
+
+    # @closed_stock_gain = 0
+    # @total_closed_stock_gain = 0
   end
 
   def initial_setup

--- a/app/views/portfolios/_portfolio.html.erb
+++ b/app/views/portfolios/_portfolio.html.erb
@@ -83,10 +83,7 @@
             <% end %>
             <td class="<%= cell %>"><%= number_to_currency(position.commission_and_fee) %></td>
             <td class="<%= cell %>"><%= number_to_currency(position_cost) %></td>
-
-            <%# stock_in_position = Stock.find_by(ticker: position.symbol) %>
-
-            <td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * position.commission_and_fee) %></td>
+            <td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * Stock.where(ticker: position.symbol, portfolio_id: position.portfolio_id).first.commission_and_fee) %></td>
             <% red_or_green = position.realized_profit_loss >= 0 ? 'text-green-600' : 'text-red-600' %>
             <td class="<%= cell %> <%= red_or_green %>"><%= number_to_currency(position.realized_profit_loss) %></td>
             <% red_or_green = position.income >= 0 ? 'text-green-600' : 'text-red-600' %>

--- a/app/views/portfolios/_portfolio.html.erb
+++ b/app/views/portfolios/_portfolio.html.erb
@@ -83,8 +83,10 @@
             <% end %>
             <td class="<%= cell %>"><%= number_to_currency(position.commission_and_fee) %></td>
             <td class="<%= cell %>"><%= number_to_currency(position_cost) %></td>
-            <% stock_in_position = Stock.find_by(ticker: position.symbol) %>
-            <td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * stock_in_position.commission_and_fee) %></td>
+
+            <%# stock_in_position = Stock.find_by(ticker: position.symbol) %>
+
+            <td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * position.commission_and_fee) %></td>
             <% red_or_green = position.realized_profit_loss >= 0 ? 'text-green-600' : 'text-red-600' %>
             <td class="<%= cell %> <%= red_or_green %>"><%= number_to_currency(position.realized_profit_loss) %></td>
             <% red_or_green = position.income >= 0 ? 'text-green-600' : 'text-red-600' %>

--- a/app/views/portfolios/_portfolio.html.erb
+++ b/app/views/portfolios/_portfolio.html.erb
@@ -83,7 +83,8 @@
             <% end %>
             <td class="<%= cell %>"><%= number_to_currency(position.commission_and_fee) %></td>
             <td class="<%= cell %>"><%= number_to_currency(position_cost) %></td>
-            <td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * Stock.where(ticker: position.symbol, portfolio_id: position.portfolio_id).first.commission_and_fee) %></td>
+            <% stock_in_position = Stock.where(ticker: position.symbol, portfolio_id: position.portfolio_id).first %>
+            <td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * stock_in_position.commission_and_fee) %></td>
             <% red_or_green = position.realized_profit_loss >= 0 ? 'text-green-600' : 'text-red-600' %>
             <td class="<%= cell %> <%= red_or_green %>"><%= number_to_currency(position.realized_profit_loss) %></td>
             <% red_or_green = position.income >= 0 ? 'text-green-600' : 'text-red-600' %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -58,11 +58,11 @@
   </div>
 
   <div class="my-5">
-    <%= form.number_field :price, min: 0.00001, step: 0.00001, class: "#{field_style}", required: true, placeholder:"Price" %>
+    <%= form.number_field :price, min: 0.000001, step: 0.000001, class: "#{field_style}", required: true, placeholder:"Price" %>
   </div>
 
   <div class="my-5">
-    <%= form.number_field :div_per_share, min: 0.00001, step: 0.00001, class: "#{field_style} hidden", placeholder:"Dividend per share" %>
+    <%= form.number_field :div_per_share, min: 0.000001, step: 0.000001, class: "#{field_style} hidden", placeholder:"Dividend per share" %>
   </div>
 
   <div class="my-5">


### PR DESCRIPTION
There was a bug in the portfolio index page, where I do calculations for the realized commission and fee column. The origin stock_in_positioin variable was getting the Stock with the position symbol, but not specifically for this portfolio. So, this is what I had:

````
<% stock_in_position = Stock.find_by(ticker: position.symbol) %>
<td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * stock_in_position.commission_and_fee) %></td>
````

and this is what I corrected it to:

````
<% stock_in_position = Stock.where(ticker: position.symbol, portfolio_id: position.portfolio_id).first %>
<td class="<%= cell %> text-red-600"><%= number_to_currency(-1 * stock_in_position.commission_and_fee) %></td>
````

Other minor changes and improvements have been included. Please, see the change log for more details.
