### PR TITLE
Shares in out

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -79,3 +79,7 @@ body {
   max-width: 128px !important;
   height: auto !important;
 }
+
+select > option:nth-child(n + 10):nth-child(-n + 14) {
+  color: red;
+}

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -9,7 +9,7 @@ class TransactionsController < ApplicationController
   # GET /transactions or /transactions.json
   def index
     reset_instance_variable
-    @transactions = Transaction.where(portfolio_id: params[:portfolio_id]).order('trade_date ASC')
+    @transactions = Transaction.where(portfolio_id: params[:portfolio_id]).order('trade_date DESC')
   end
 
   # GET /transactions/1 or /transactions/1.json

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -116,7 +116,7 @@ module TransactionsHelper
       transaction.quantity = @stock.shares_owned
     end
     if transaction.tr_type == 'Symbol Change'
-      @historical_transactions = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id).includes([:portfolio]).order('trade_date ASC')
+      @historical_transactions = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id).order('trade_date ASC')
       @historical_transactions.each do |trans|
         trans.update(symbol: transaction.new_symbol)
         trans.save

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -56,20 +56,20 @@ module TransactionsHelper
 
   def closing_date_earlier_than_opening_date?(transaction)
     if transaction.tr_type == 'Sell' || transaction.tr_type == 'Reinvest Div.'
-      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, tr_type: 'Buy').order('trade_date ASC').first.trade_date
+      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id, tr_type: 'Buy').order('trade_date ASC').first.trade_date
     elsif transaction.tr_type == 'Buy to cover'
-      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, tr_type: 'Sell short').order('trade_date ASC').first.trade_date
+      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id, tr_type: 'Sell short').order('trade_date ASC').first.trade_date
     elsif transaction.tr_type == 'Cash In' || transaction.tr_type == 'Interest Inc.'
       existing_stock_opened_date = @portfolio.opened_date
     elsif transaction.tr_type == 'Cash Out' || transaction.tr_type == 'Misc. Exp.'
-      cash_in = Transaction.where(symbol: transaction.symbol, tr_type: 'Cash In').order('trade_date ASC').first ||
-                Transaction.where(symbol: transaction.symbol, tr_type: 'Interest Inc.').order('trade_date ASC').first
+      cash_in = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id, tr_type: 'Cash In').order('trade_date ASC').first ||
+                Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id, tr_type: 'Interest Inc.').order('trade_date ASC').first
       cash_in == nil ? existing_stock_opened_date = @portfolio.opened_date : existing_stock_opened_date = cash_in.trade_date
     elsif transaction.tr_type == 'Stock Split' || transaction.tr_type == 'Dividend'
-      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, tr_type: 'Buy').order('trade_date ASC').first.trade_date if long_position_exist?(transaction)
-      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, tr_type: 'Sell short').order('trade_date ASC').first.trade_date if short_position_exist?(transaction)
+      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id, tr_type: 'Buy').order('trade_date ASC').first.trade_date if long_position_exist?(transaction)
+      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id, tr_type: 'Sell short').order('trade_date ASC').first.trade_date if short_position_exist?(transaction)
     elsif transaction.tr_type == 'Symbol Change'
-      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol).order('trade_date ASC').first.trade_date if @stock_symbols.include?(transaction.symbol)
+      existing_stock_opened_date = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id).order('trade_date ASC').first.trade_date if @stock_symbols.include?(transaction.symbol)
     end
     transaction.trade_date < existing_stock_opened_date
   end
@@ -89,7 +89,7 @@ module TransactionsHelper
   end
 
   def adjust_stock_split(transaction)
-    @historical_transactions = Transaction.where(symbol: transaction.symbol).order('trade_date ASC')
+    @historical_transactions = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id).order('trade_date ASC')
     @historical_transactions.each do |trans|
       if trans.trade_date < transaction.trade_date && trans.tr_type != 'Stock Split'
         trans.update(quantity: trans.quantity * transaction.new_shares.to_f / transaction.old_shares.to_f)
@@ -116,10 +116,7 @@ module TransactionsHelper
       transaction.quantity = @stock.shares_owned
     end
     if transaction.tr_type == 'Symbol Change'
-      @historical_transactions = Transaction.where(symbol: transaction.symbol).order('trade_date ASC')
-      puts @historical_transactions
-      puts 'New symbol is: '
-      puts transaction.new_symbol
+      @historical_transactions = Transaction.where(symbol: transaction.symbol, portfolio_id: transaction.portfolio_id).includes([:portfolio]).order('trade_date ASC')
       @historical_transactions.each do |trans|
         trans.update(symbol: transaction.new_symbol)
         trans.save

--- a/app/javascript/controllers/forms_controller.js
+++ b/app/javascript/controllers/forms_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   }
 
   initialize() {
-    this.element.setAttribute('data-action', 'change->forms#handleChange'); // This  input->forms#handleInput is not working
+    this.element.setAttribute('data-action', 'change->forms#handleChange');
   }
 
   getFields(transactionType) {
@@ -48,8 +48,8 @@ export default class extends Controller {
     });
   }
 
-  showField(filedName) {
-    const field = document.getElementById(filedName);
+  showField(fieldName) {
+    const field = document.getElementById(fieldName);
     field.classList.remove('hidden');
     field.setAttribute('required', 'true');
     field.setAttribute('value', '');
@@ -130,6 +130,11 @@ export default class extends Controller {
     });
   }
 
+  handleQuantity() {
+    const price = document.getElementById('transaction_price');
+    price.setAttribute('placeholder', 'Average price per share');
+  }
+
   handleChange(event) {
     event.preventDefault();
     const selectedTransactionType = document.getElementById('transaction_tr_type');
@@ -162,16 +167,21 @@ export default class extends Controller {
         this.hideCommonFields();
         this.hideFieldsForSymbolChange();
         break;
+      case 'Shares in':
+        this.showAllFields();
+        this.hideCommonFields();
+        this.hideUncommonFields();
+        this.handleQuantity();
+        break;
+      case 'Shares out':
+        this.showAllFields();
+        this.hideCommonFields();
+        this.hideUncommonFields();
+        this.addHidden(document.getElementById('transaction_price'));
+        break;
       default:
         this.showAllFields();
         this.hideUncommonFields();
     }
   }
-
-  // handleInput(event) {
-  //   const symbol = document.getElementById('transaction_symbol');
-  //   const newSymbol = document.getElementById('transaction_new_symbol');
-  //   symbol.value = symbol.value.toUpperCase();
-  //   newSymbol.value = newSymbol.value.toUpperCase();
-  // }
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,8 +38,8 @@
   <% end %>
 
   <div class="flex flex-col items-center">
-    <h3 class="mt-12 text-sm text-center">Whant to cancel my account?</h3>
+    <h3 class="mt-8 text-sm text-center">Whant to cancel my account?</h3>
     <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?", turbo_method: :delete }, method: :delete, class: "mt-2 rounded-lg py-1 px-3 bg-dollar-triad_red font-medium text-white hover:bg-dollar-square_red" %>
-    <%= link_to "Back", :back, class: "mt-12 rounded-lg py-1 px-3 bg-dollar-split_blue inline-block font-medium text-white hover:bg-dollar-triad_blue" %>
+    <%= link_to "Back", :back, class: "mt-8 rounded-lg py-1 px-3 bg-dollar-split_blue inline-block font-medium text-white hover:bg-dollar-triad_blue" %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-12 px-5 flex-col">
+    <main class="container mx-auto mt-8 px-5 flex-col">
       <div class="container flex justify-center align-center">
         <% if notice %>
           <span class="bg-green-100 text-green-500 mb-2 p-2 rounded-md"><%= notice %></span>
@@ -60,8 +60,8 @@
         </nav>
       </header>
       <%= yield %>
-      <footer class="flex flex-col justify-center items-center container bg-dollar h-14 my-16">
-        <div class="">
+      <footer class="flex flex-col justify-center items-center container bg-dollar h-14 my-16 mb-8">
+        <div>
           <p>Copyright<sup>&copy;</sup> 2022-2023 <%= link_to 'AXE_BIT', 'https://yuriy-portfolio.netlify.app/',  target: :'_blank', rel: :'noopener noreferrer', class:"text-dollar-split_blue font-bold hover:text-dollar-complement" %>. All  rights reserved.</p>
         </div>
       </footer>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -31,6 +31,7 @@
       ['Shares in', 'Shares in'],
       ['Shares out', 'Shares out']],
       class:"#{field_style} text-red-800", required: true %>
+      <sup class="block-inline text-red-600 text-lg"> **</sup>
   </div>
 
   <div class="my-5">
@@ -85,12 +86,12 @@
     <%= form.text_field :notes, class: "#{field_style}", placeholder:"Notes" %>
   </div>
 
-  <div class="my-5">
-    <span class="text-sm text-red-600">* All transactions have to be recorded chronologicaly.</span><br>
-    <span class="text-sm text-red-600">** For 'Shares in' type, enter 0 for 'Average price per share' if received as a gift or matching shares.</span>
+  <div class="mt-5">
+    <div class="text-xs text-red-600 leading-3">* All transactions have to be recorded chronologicaly.</div>
+    <div class="text-xs text-red-600 leading-3">** For 'Shares in' type, enter 0 for 'Average price per share' if received as a gift or matching shares.</div>
   </div>
 
-  <div class="inline">
+  <div class="flex justify-center">
     <%= form.submit class: "mt-8 rounded-lg py-1 px-3 bg-dollar-split_blue inline-block font-medium text-white hover:bg-dollar-triad_blue" %>
   </div>
 <% end %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -27,7 +27,9 @@
       ['Dividend', 'Dividend'],
       ['Reinvest Div.', 'Reinvest Div.'],
       ['Stock Split', 'Stock Split'],
-      ['Symbol Change', 'Symbol Change']],
+      ['Symbol Change', 'Symbol Change'],
+      ['Shares in', 'Shares in'],
+      ['Shares out', 'Shares out']],
       class:"#{field_style} text-red-800", required: true %>
   </div>
 
@@ -57,7 +59,7 @@
     <%= form.number_field :old_shares, class: "#{field_style} hidden", placeholder:"Old shares ratio" %>
   </div>
 
-  <div class="my-5">
+  <div class="my-5" id="price-div">
     <%= form.number_field :price, min: 0.000001, step: 0.000001, class: "#{field_style}", required: true, placeholder:"Price" %>
   </div>
 
@@ -78,6 +80,15 @@
   </div>
 
   <%= form.hidden_field :portfolio_id, value: @portfolio.id %>
+
+  <div class="my-5 hidden">
+    <%= form.text_field :notes, class: "#{field_style}", placeholder:"Notes" %>
+  </div>
+
+  <div class="my-5">
+    <span class="text-sm text-red-600">* All transactions have to be recorded chronologicaly.</span><br>
+    <span class="text-sm text-red-600">** For 'Shares in' type, enter 0 for 'Average price per share' if received as a gift or matching shares.</span>
+  </div>
 
   <div class="inline">
     <%= form.submit class: "mt-8 rounded-lg py-1 px-3 bg-dollar-split_blue inline-block font-medium text-white hover:bg-dollar-triad_blue" %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -15,6 +15,7 @@
   <% field_style = "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
 
   <div class="my-5">
+    <label for="transaction_tr_type"></label>
     <%= form.select :tr_type, [["Transaction type", ''],
       ['Buy', 'Buy'],
       ['Sell', 'Sell'],
@@ -24,14 +25,14 @@
       ['Cash Out', 'Cash Out'],
       ['Interest Inc.', 'Interest Inc.'],
       ['Misc. Exp.', 'Misc. Exp.'],
-      ['Dividend', 'Dividend'],
-      ['Reinvest Div.', 'Reinvest Div.'],
-      ['Stock Split', 'Stock Split'],
-      ['Symbol Change', 'Symbol Change'],
-      ['Shares in', 'Shares in'],
+      ['Dividend ***', 'Dividend'],
+      ['Reinvest Div. ***', 'Reinvest Div.'],
+      ['Stock Split ***', 'Stock Split'],
+      ['Symbol Change ***', 'Symbol Change'],
+      ['Shares in **', 'Shares in'],
       ['Shares out', 'Shares out']],
       class:"#{field_style} text-red-800", required: true %>
-      <sup class="block-inline text-red-600 text-lg"> **</sup>
+      <sup class="block-inline text-red-600 text-lg ml-1"> **, ***</sup>
   </div>
 
   <div class="my-5">
@@ -82,13 +83,10 @@
 
   <%= form.hidden_field :portfolio_id, value: @portfolio.id %>
 
-  <div class="my-5 hidden">
-    <%= form.text_field :notes, class: "#{field_style}", placeholder:"Notes" %>
-  </div>
-
   <div class="mt-5">
     <div class="text-xs text-red-600 leading-3">* All transactions have to be recorded chronologicaly.</div>
-    <div class="text-xs text-red-600 leading-3">** For 'Shares in' type, enter 0 for 'Average price per share' if received as a gift or matching shares.</div>
+    <div class="text-xs text-red-600 leading-3">** Enter 0 for 'Average price per share' if received as a gift or matching shares.</div>
+    <div class="text-xs text-red-600 leading-3">*** Must be entered in each portfolio, which holds the same stock separetely.</div>
   </div>
 
   <div class="flex justify-center">

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-1/4 w-full">
-  <h1 class="font-bold text-2xl">New transaction</h1>
+  <h1 class="font-bold text-2xl text-center mt-12 mb-8">New transaction<sup class="block-inline text-red-600"> *</sup></h1>
   <%= render "form", transaction: @transaction %>
-  <%= link_to 'Back to transactions', user_portfolio_transactions_path, class: "mt-8 rounded-lg py-1 px-3 bg-dollar-split_blue inline-block font-medium text-white hover:bg-dollar-triad_blue" %>
+  <%= link_to 'Back to transactions', user_portfolio_transactions_path, class: "w-fit mt-8 mx-auto rounded-lg py-1 px-3 bg-dollar-split_blue block font-medium text-white hover:bg-dollar-triad_blue" %>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,7 +86,7 @@ Rails.application.configure do
   # Adding config for bullet gem
   config.after_initialize do
     Bullet.enable = true
-    Bullet.sentry = true
+    # Bullet.sentry = true
     Bullet.alert = true
     Bullet.bullet_logger = true
     Bullet.console = true


### PR DESCRIPTION
There was a bug in the previous version, where a user could record a "Sell" transaction, before a corresponding "Buy" transaction in the same portfolio. It was due to searching in all the transactions, but not specific to this portfolio for the "Buy" transaction. So, the transaction will be executed if you had a "Buy" transaction in one of the portfolios, which has a date before the "Sell" transaction in another portfolio. The fix is in the `transactions_helper.rb#closing_date_earlier_than_opening_date?` method.
Also, the "Sentry" option in the `bullet` gem was enabled, which gives an error and this option has been disabled.